### PR TITLE
Now agent can send data through SOCK4 and SOCKS 5 proxy types. 

### DIFF
--- a/pyZabbixSender/pyZabbixSender.py
+++ b/pyZabbixSender/pyZabbixSender.py
@@ -6,6 +6,7 @@
 # License: GNU GPLv2
 
 import socket
+import socks
 import struct
 import time
 import sys

--- a/pyZabbixSender/pyZabbixSender.py
+++ b/pyZabbixSender/pyZabbixSender.py
@@ -36,6 +36,9 @@ class pyZabbixSender(pyZabbixSenderBase):
         data_header = str(struct.pack('q', data_length))
         data_to_send = 'ZBXD\1' + str(data_header) + str(mydata)
         try:
+            if self.netproxy:
+                socks.set_default_proxy(self.sockstype, self.netproxy, self.proxyport)
+                socket.socket = socks.socksocket
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect((self.zserver, self.zport))
             sock.send(data_to_send)

--- a/pyZabbixSender/pyZabbixSender.py
+++ b/pyZabbixSender/pyZabbixSender.py
@@ -37,8 +37,12 @@ class pyZabbixSender(pyZabbixSenderBase):
         data_to_send = 'ZBXD\1' + str(data_header) + str(mydata)
         try:
             if self.netproxy:
-                socks.set_default_proxy(self.sockstype, self.netproxy, self.proxyport)
-                socket.socket = socks.socksocket
+		if self.proxytype == 5:
+                	socks.set_default_proxy(socks.SOCKS5, self.netproxy, self.proxyport)
+                	socket.socket = socks.socksocket
+		else:
+			socks.set_default_proxy(socks.SOCKS4, self.netproxy, self.proxyport)
+			socket.socket = socks.socksocket
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect((self.zserver, self.zport))
             sock.send(data_to_send)

--- a/pyZabbixSender/pyZabbixSenderBase.py
+++ b/pyZabbixSender/pyZabbixSenderBase.py
@@ -27,7 +27,7 @@ class pyZabbixSenderBase:
     ZABBIX_SERVER = "127.0.0.1"
     ZABBIX_PORT   = 10051
 
-    def __init__(self, server=ZABBIX_SERVER, port=ZABBIX_PORT, verbose=False):
+    def __init__(self, server=ZABBIX_SERVER, port=ZABBIX_PORT, proxytype=False, netproxy=False, proxyport=False, verbose=False):
         '''
         #####Description:
         This is the constructor, to obtain an object of type pyZabbixSender, linked to work with a specific server/port.
@@ -44,6 +44,9 @@ class pyZabbixSenderBase:
         '''
         self.zserver = server
         self.zport   = port
+        self.netproxy = netproxy
+        self.proxytype = proxytype
+        self.proxyport = proxyport
         self.verbose = verbose
         self.timeout = 5         # Socket connection timeout.
         self._data = []         # This is to store data to be sent later.

--- a/test.py
+++ b/test.py
@@ -4,8 +4,16 @@ from pyZabbixSender import pyZabbixSender
 # to some data points, for example/testing purposes only.
 import time
 
-# Specifying server, but using default port
+# If the server where pyZabbixSender located does not have a direct Internet 
+# connection you can specify proxy settings: 
+# pyZabbixSender(
+# 	server="Zabbix_ip", 
+# 	port="Zabbix_port", 
+# 	sockstype="socks.SOCKS5", 
+# 	netproxy="proxy_ip", 
+# 	proxyport=8080)
 z = pyZabbixSender("127.0.0.1")
+
 
 def printBanner(text):
     border_char = '#'

--- a/test.py
+++ b/test.py
@@ -6,11 +6,11 @@ import time
 
 # If the server where pyZabbixSender located does not have a direct Internet 
 # connection you can specify proxy settings: 
-# pyZabbixSender(
-# 	server="Zabbix_ip", 
-# 	port="Zabbix_port", 
-# 	sockstype="socks.SOCKS5", 
-# 	netproxy="proxy_ip", 
+# z = pyZabbixSender(
+# 	server="127.0.0.1", 
+# 	port=10051, 
+# 	proxytype=5, 
+# 	netproxy="127.0.0.1", 
 # 	proxyport=8080)
 z = pyZabbixSender("127.0.0.1")
 


### PR DESCRIPTION
If the server where pyZabbixSender located does not have a direct Internet
connection you can specify proxy settings:
```
z = pyZabbixSender(
       server="127.0.0.1",
       port=10051,
       proxytype=5,
       netproxy="proxy_ip",
       proxyport=8080)
```
